### PR TITLE
#4: Fix Knuckles being able to climb spikes while invincible

### DIFF
--- a/Assets/Resources/Regular Stage/Player/ScriptableObjects/CharacterPhysicsScriptableObject.cs
+++ b/Assets/Resources/Regular Stage/Player/ScriptableObjects/CharacterPhysicsScriptableObject.cs
@@ -143,6 +143,10 @@ public class CharacterPhysicsScriptableObject : ScriptableObject
     public List<Vector2> pullUpPositionIncrements = new List<Vector2> { new Vector2(4, -6), new Vector2(4, 9), new Vector2(4, 8), new Vector2(4, 7), new Vector2(4, 7) };
     [Tooltip("The pull up animation"), LastFoldoutItem()]
     public AnimationClip pullUpAnimationClip;
+    [Tooltip("List of classes of that cannot be climbed"), IsDisabled]
+    public readonly List<string> nonClimbableObjectControllers = new List<string> {
+        typeof(SpikeController).ToString(),
+    };
 
     [Tooltip("Special Stage Gravity"), FirstFoldOutItem("Special Stage Variables")]
     public float specialStageCurrentGravity = 0.21875f;


### PR DESCRIPTION
## Issue ticket 
- https://github.com/DamiTheHuman/quill-framework/issues/4

## Changes
- Added a list of '"non-climbable" objects to stop the player from climbing things they shouldn't

## Testing Instructions
- Play as Knuckles and get hit
- Try and climb a spike, the player should be stopped even though the spike is solid
